### PR TITLE
Overhaul collision mask code

### DIFF
--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "dependencies": [
     "base >= 1.1.0",
     "? laser_tanks_updated >= 0.19.0",
-    "(?) laser_tanks > 0.18.15"
+    "(?) laser_tanks > 0.18.15",
+    "(?) space-exploration"
   ]
 }

--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -9,6 +9,7 @@ local collision = table.deepcopy(data.raw.car.car)
   collision.name = "hovercraft-collision"
   collision.order = "hovercraft-collision"
   collision.collision_box = {{-1.5, -1.5}, {1.5, 1.5}}
+  collision.collision_mask = { "player-layer" }  -- Will be replaced by custom collision layer in data-final-fixes
   collision.animation = {filename = "__core__/graphics/empty.png", size = 1, direction_count = 1}
   collision.turret_animation = nil
   collision.light_animation = nil
@@ -36,7 +37,7 @@ hcraft_entity.tank_driving = true
 hcraft_entity.weight = 2500
 hcraft_entity.minable = {mining_time = 0.5, result = "hcraft-entity"}
 hcraft_entity.has_belt_immunity = true
-hcraft_entity.collision_mask = { "train-layer", "layer-14" } --{, "not-colliding-with-itself"}
+hcraft_entity.collision_mask = { "player-layer" }  -- Will be replaced by custom collision layer in data-final-fixes
 hcraft_entity.resistances = {
   { type = "fire",      decrease = 7.5, percent = 30 },
   { type = "physical",  decrease = 7.5, percent = 30 },


### PR DESCRIPTION
This PR massively simplifies the data-stage collision mask code, which results in several bug fixes:

- Fixed `hovercraft-collision` colliding with water, which caused drifting over water to not work. This was particularly apparent when drifting over a land/water border
- Fixed trains colliding with walls (https://mods.factorio.com/mod/Hovercrafts/discussion/6181b19499129db2c2577a89)
- Fixed not being able to walk through SE pipes (https://mods.factorio.com/mod/Hovercrafts/discussion/61b19c0e7a19f2772f5262e8)
- Fixed SE core miners not being able to be placed on core seams
- Stopped using a hardcoded collision mask (`layer-14`) which could cause compatibility issues with mods that use the same mask for something else

Also removed compatibility code for DeadlockLargerLamp and traintunnels since it is no longer needed.