### PR TITLE
Tank parity (remote drive, equipment grid)

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,20 +1,6 @@
 -- data-updates.lua
 require("constants")
 
--- add equipment grid to hovercraft and missile-hovercraft if startup setting selected
-if settings.startup["hovercraft-grid"].value then
-  local crafts = {
-    ["hovercraft"] = "hovercraft-equipment",
-    ["missile-hovercraft"] = "missile-hovercraft-equipment",
-  }
-  for vehiculename, vehiculegrid in pairs(crafts) do
-    local entity = data.raw.car[vehiculename]
-    if entity then
-      entity.equipment_grid = vehiculegrid
-    end
-  end
-end
-
 --[[if mods["justgo"] then
   local function generate_migration_item(name) -- not sure if the "just go" dude will fix it...
     if data.raw["item-with-entity-data"][name] then

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -59,7 +59,6 @@ hovercraft-drifting=Hovercraft drifting
 enable-electric-hovercraft=Electric hovercraft
 enable-missile-hovercraft=Missile hovercraft
 enable-laser-hovercraft=Laser hovercraft
-hovercraft-grid=Hovercraft equipment grid
 hovercraft-grid-size=Hovercraft grid dimensions
 missile-hovercraft-grid-size=Missile hovercraft grid dimensions
 
@@ -68,6 +67,5 @@ hovercraft-drifting=Enables hovercraft to drift while turning.  Warning: Chance 
 enable-electric-hovercraft=Enables access to the electric hovercraft
 enable-missile-hovercraft=Enables access to the missile hovercraft
 enable-laser-hovercraft=Enables access to the laser hovercraft
-hovercraft-grid=Enables an equipment grid for the hovercraft and missile-hovercraft.
 hovercraft-grid-size=Changes the dimensions of the hovercraft's equipment grid.
 missile-hovercraft-grid-size=Changes the dimensions of the missile-hovercraft's equipment grid.

--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -36,6 +36,9 @@ hcraft_entity.tank_driving = true
 hcraft_entity.weight = 2500
 hcraft_entity.minable = {mining_time = 0.5, result = "hovercraft"}
 hcraft_entity.has_belt_immunity = true
+hcraft_entity.allow_remote_driving = true
+hcraft_entity.equipment_grid = "hovercraft-equipment"
+hcraft_entity.trash_inventory_size = 20
 hcraft_entity.collision_mask = { layers = {player = true} }  -- Will be replaced by custom collision layer in data-final-fixes
 hcraft_entity.resistances = {
   { type = "fire",      decrease = 7.5, percent = 30 },
@@ -119,6 +122,7 @@ if missile_hovercraft_activated then
   mcraft_entity.immune_to_tree_impacts = true
   mcraft_entity.immune_to_rock_impacts = true
   mcraft_entity.weight = 10000
+  mcraft_entity.equipment_grid = "missile-hovercraft-equipment"
   mcraft_entity.minable = {mining_time = 0.5, result = "missile-hovercraft"}
   mcraft_entity.resistances = {
     { type = "fire",      decrease = 10, percent = 55 },

--- a/prototypes/equipment.lua
+++ b/prototypes/equipment.lua
@@ -1,49 +1,47 @@
 ----------------------------------------------------------------------------------------------------------------------------------
----------------------------------------------------EQUIPEMENT GRID----------------------------------------------------------------
+---------------------------------------------------EQUIPMENT GRID----------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------------------------------------
 
-if settings.startup["hovercraft-grid"].value then
-  local hgridw, hgridh = string.match(settings.startup["hovercraft-grid-size"].value, "(%d+)x(%d+)")
-  log("grid-hovercraft = " .. tostring(settings.startup["hovercraft-grid-size"].value) .. " " .. tostring(hgridw) .. ", " .. tostring(hgridh))
+local hgridw, hgridh = string.match(settings.startup["hovercraft-grid-size"].value, "(%d+)x(%d+)")
+log("grid-hovercraft = " .. tostring(settings.startup["hovercraft-grid-size"].value) .. " " .. tostring(hgridw) .. ", " .. tostring(hgridh))
+
+data:extend({
+  {
+    type = "equipment-grid",
+    name = "hovercraft-equipment",
+    width = tonumber(hgridw) or 2,
+    height = tonumber(hgridh) or 2,
+    equipment_categories = {"armor"}
+  }
+})
+
+if mods["bobvehicleequipment"] then
+  data.raw["equipment-grid"]["hovercraft-equipment"].equipment_categories = {"car", "vehicle"}
+end
+if mods["vtk-armor-plating"] then
+  table.insert(data.raw["equipment-grid"]["hovercraft-equipment"].equipment_categories, "vtk-armor-plating")
+end
+
+----------------------------------------------------------------------------------------------------------------------------------
+if missile_hovercraft_activated then
+  local mgridw, mgridh = string.match(settings.startup["missile-hovercraft-grid-size"].value, "(%d+)x(%d+)")
+  log("grid-missile-hovercraft = " .. tostring(settings.startup["missile-hovercraft-grid-size"].value) .. " " .. tostring(mgridw) .. ", " .. tostring(mgridh))
 
   data:extend({
     {
       type = "equipment-grid",
-      name = "hovercraft-equipment",
-      width = hgridw or 2,
-      height = hgridh or 2,
+      name = "missile-hovercraft-equipment",
+      width = tonumber(mgridw) or 4,
+      height = tonumber(mgridh) or 2,
       equipment_categories = {"armor"}
     }
   })
 
   if mods["bobvehicleequipment"] then
-    data.raw["equipment-grid"]["hovercraft-equipment"].equipment_categories = {"car", "vehicle"}
+    data.raw["equipment-grid"]["missile-hovercraft-equipment"].equipment_categories = {"tank", "vehicle", "armoured-vehicle"}
   end
   if mods["vtk-armor-plating"] then
-    table.insert(data.raw["equipment-grid"]["hovercraft-equipment"].equipment_categories, "vtk-armor-plating")
-  end
-
-----------------------------------------------------------------------------------------------------------------------------------
-  if missile_hovercraft_activated then
-    local mgridw, mgridh = string.match(settings.startup["missile-hovercraft-grid-size"].value, "(%d+)x(%d+)")
-    log("grid-missile-hovercraft = " .. tostring(settings.startup["missile-hovercraft-grid-size"].value) .. " " .. tostring(mgridw) .. ", " .. tostring(mgridh))
-
-    data:extend({
-      {
-        type = "equipment-grid",
-        name = "missile-hovercraft-equipment",
-        width = mgridw or 4,
-        height = mgridh or 2,
-        equipment_categories = {"armor"}
-      }
-    })
-
-    if mods["bobvehicleequipment"] then
-      data.raw["equipment-grid"]["missile-hovercraft-equipment"].equipment_categories = {"tank", "vehicle", "armoured-vehicle"}
-    end
-    if mods["vtk-armor-plating"] then
-      table.insert(data.raw["equipment-grid"]["missile-hovercraft-equipment"].equipment_categories, "vtk-armor-plating")
-    end
+    table.insert(data.raw["equipment-grid"]["missile-hovercraft-equipment"].equipment_categories, "vtk-armor-plating")
   end
 end
 

--- a/settings.lua
+++ b/settings.lua
@@ -1,17 +1,19 @@
 -- settings.lua
 
 local grid_dimensions = {
-  "2x2",
-  "4x2",
   "4x4",
   "6x2",
   "6x4",
   "6x6",
+  "6x8",
   "8x2",
   "8x4",
-  "8x6",
   "8x8",
   "10x2",
+  "10x4",
+  "10x6",
+  "10x8",
+  "10x10",
 }
 
 data:extend({
@@ -43,17 +45,10 @@ data:extend({
     order = "d",
   },
   {
-    type = "bool-setting",
-    name = "hovercraft-grid",
-    setting_type = "startup",
-    default_value = false,
-    order = "e",
-  },
-  {
     type = "string-setting",
     name = "hovercraft-grid-size",
     setting_type = "startup",
-    default_value = "2x2",
+    default_value = "6x8",
     allowed_values = grid_dimensions,
     order = "f",
   },
@@ -61,7 +56,7 @@ data:extend({
     type = "string-setting",
     name = "missile-hovercraft-grid-size",
     setting_type = "startup",
-    default_value = "4x2",
+    default_value = "8x8",
     allowed_values = grid_dimensions,
     order = "g",
   },

--- a/settings.lua
+++ b/settings.lua
@@ -2,8 +2,8 @@
 
 local grid_dimensions = {
   "4x4",
+  "4x6",
   "6x2",
-  "6x4",
   "6x6",
   "6x8",
   "8x2",
@@ -48,7 +48,7 @@ data:extend({
     type = "string-setting",
     name = "hovercraft-grid-size",
     setting_type = "startup",
-    default_value = "6x8",
+    default_value = "4x6",
     allowed_values = grid_dimensions,
     order = "f",
   },
@@ -56,7 +56,7 @@ data:extend({
     type = "string-setting",
     name = "missile-hovercraft-grid-size",
     setting_type = "startup",
-    default_value = "8x8",
+    default_value = "6x6",
     allowed_values = grid_dimensions,
     order = "g",
   },


### PR DESCRIPTION
In 2.0, tanks can be driven remotely and have 8x6 equipment grids. This PR adds that to hovercrafts too.